### PR TITLE
Bison 3.0 patch

### DIFF
--- a/gstreamer-0.10/Buildfile
+++ b/gstreamer-0.10/Buildfile
@@ -16,6 +16,10 @@ build() {
                --prefix=/usr \
                --disable-{examples,tests,loadsave}
 
+   if bison -V | head -1 | fgrep -q " 3." ; then
+      sed -i  -e '/YYLEX_PARAM/d' -e '/parse-param.*scanner/i %lex-param { void *scanner }' gst/parse/grammar.y
+   fi
+
    make -j $JOBS
    make DESTDIR=$PKG install
 


### PR DESCRIPTION
0.10 is abandoned, so there is a bit cryptic change to get things working with bison-3.0. Basicly YYLEX_PARAM is replaced by lex-param. See https://bugzilla.gnome.org/show_bug.cgi?id=706462

BTW: In cross-qt/webkit/ANGLE/glslang.y has same problem. Its (also) easily fixed adding after parse-param:
%lex-param {YYLEX_PARAM}

Signed-off-by: Jari Vanhala jari.vanhala@ixonos.com
