### PR TITLE
fix sourceforge source urls

### DIFF
--- a/iperf/Buildfile
+++ b/iperf/Buildfile
@@ -5,7 +5,7 @@
 name=iperf
 version=2.0.5
 release=1
-source=(http://surfnet.dl.sourceforge.net/project/iperf/iperf-$version.tar.gz)
+source=(http://downloads.sourceforge.net/project/iperf/iperf-$version.tar.gz)
 depends=(util-linux)
 
 build() {

--- a/libical/Buildfile
+++ b/libical/Buildfile
@@ -5,7 +5,7 @@
 name=libical
 version=1.0
 release=1
-source=(http://switch.dl.sourceforge.net/project/freeassociation/libical/libical-1.0/$name-$version.tar.gz)
+source=(http://downloads.sourceforge.net/project/freeassociation/libical/libical-1.0/$name-$version.tar.gz)
 depends=zlib
 
 build() {

--- a/libungif/Buildfile
+++ b/libungif/Buildfile
@@ -5,7 +5,7 @@
 name=libungif
 version=4.1.4
 release=1
-source=(http://switch.dl.sourceforge.net/project/giflib/$name-4.x/$name-4.1.4/$name-$version.tar.gz)
+source=(http://downloads.sourceforge.net/project/giflib/$name-4.x/$name-4.1.4/$name-$version.tar.gz)
 
 build() {
    cd $name-$version

--- a/mpg123/Buildfile
+++ b/mpg123/Buildfile
@@ -5,7 +5,7 @@
 name=mpg123
 version=1.17.0
 release=1
-source=(http://surfnet.dl.sourceforge.net/project/$name/$name/$version/$name-$version.tar.bz2)
+source=(http://downloads.sourceforge.net/project/$name/$name/$version/$name-$version.tar.bz2)
 depends=()
 
 build() {

--- a/oprofile/Buildfile
+++ b/oprofile/Buildfile
@@ -5,7 +5,7 @@
 name=oprofile
 version=0.9.9
 release=1
-source=(http://prdownloads.sourceforge.net/$name/$name-$version.tar.gz)
+source=(http://downloads.sourceforge.net/$name/$name-$version.tar.gz)
 depends=(popt which)
 
 build() {

--- a/strace/Buildfile
+++ b/strace/Buildfile
@@ -5,7 +5,7 @@
 name=strace
 version=4.8
 release=1
-source=(http://surfnet.dl.sourceforge.net/project/$name/$name/$version/$name-$version.tar.xz)
+source=(http://downloads.sourceforge.net/project/$name/$name/$version/$name-$version.tar.xz)
 
 build() {
    cd $name-$version

--- a/traceroute/Buildfile
+++ b/traceroute/Buildfile
@@ -5,7 +5,7 @@
 name=traceroute
 version=2.0.19
 release=1
-source=(http://heanet.dl.sourceforge.net/project/$name/$name/$name-$version/$name-$version.tar.gz)
+source=(http://downloads.sourceforge.net/project/$name/$name/$name-$version/$name-$version.tar.gz)
 
 build() {
    cd $name-$version


### PR DESCRIPTION
Seem that sometimes there some change of sourceforge mirrors. so it is
best to use urls of the main download site, which direct to working mirror.

Signed-off-by: Kalle Lampila kalle.lampila@ixonos.com
