### PR TITLE
rfkill: set release to version suffix

### DIFF
--- a/rfkill/Buildfile
+++ b/rfkill/Buildfile
@@ -10,6 +10,6 @@ source=(https://www.kernel.org/pub/software/network/rfkill/rfkill-0.5.tar.xz)
 build() {
    cd $name-$version
 
-   make CC=$HOST-gcc
+   make VERSION_SUFFIX=$release CC=$HOST-gcc
    make DESTDIR=$PKG install
 }


### PR DESCRIPTION
If version suffix is not set, then compilation try look it from
git version. This can cause problems because rfkill is not from git,
but it it compile inside distribution git directory.
